### PR TITLE
Update cache_file_stored to grab a complete list of devids out of the DB...

### DIFF
--- a/lib/MogileFS/Plugin/ActiveCache.pm
+++ b/lib/MogileFS/Plugin/ActiveCache.pm
@@ -33,8 +33,15 @@ sub cache_file_stored {
 	my $path  = $args->{path};
 	my $checksum = $args->{checksum};
 
+	my $fid = MogileFS::FID->new($fidid);
+
+	my @fid_devids;
+	Mgd::get_store()->slaves_ok(sub {
+		@fid_devids = $fid->devids;
+	});
+
 	set_mogfid($dmid, $key, $fidid);
-	set_mogdevids($fidid, $devid);
+	set_mogdevids($fidid, @fid_devids);
 }
 
 sub cache_plugin_file_migrated {


### PR DESCRIPTION
... instead of assuming there's just one in args. This gives us compatibility with a branch of mogilefsd that can create_close to multiple devs at once.
